### PR TITLE
Fix bug where Scheduler uses array indices instead of Node uids when resorting nodes wrt cores/memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Simulator for Scheduling jobs on Cluster with hardware-composability features
+
+This is a work-in-progress application for simulating the scheduling of Jobs on a cluster that features hardware-composability such as memory borrowing.
+
+## Compiling
+
+To compile, run:
+
+```bash
+cargo build --release
+```
+
+## Testing
+
+```bash
+cargo test
+```
+
+## Examples
+
+### Simulate memory borrowing
+
+To execute, run:
+
+```bash
+cargo run  --release --bin=dismem examples/dismem_racks/nodes.csv examples/dismem_racks/connections.csv examples/dismem_racks/tiny.jobs
+```

--- a/src/LICENSE
+++ b/src/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/src/job_factory.rs
+++ b/src/job_factory.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 use crate::job::reset_job_metadata;
 use crate::job::Job;
 use std::collections::VecDeque;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 pub mod job;
 pub mod job_factory;
 pub mod node;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 use std::env::args;
 use std::path::Path;
 
@@ -35,7 +54,6 @@ fn main() -> Result<(), String> {
     let mut last_report: usize = 0;
     let report_every = 1000;
     while sched.tick() {
-
         if sched.jobs_done.len() >= report_every + last_report {
             last_report = sched.jobs_done.len();
             println!("Jobs finished {} on {}", last_report, sched.now);

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,15 @@ fn main() -> Result<(), String> {
 
     let mut sched = scheduler::Scheduler::new(registry, jfactory);
 
-    while sched.tick() {}
+    let mut last_report: usize = 0;
+    let report_every = 1000;
+    while sched.tick() {
+
+        if sched.jobs_done.len() >= report_every + last_report {
+            last_report = sched.jobs_done.len();
+            println!("Jobs finished {} on {}", last_report, sched.now);
+        }
+    }
 
     println!(
         "Scheduled {} jobs in simulated seconds {}",

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 use crate::resource;
 
 use std::fmt::{Display, Formatter};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 use crate::node::Node;
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 pub struct Resource {
     pub capacity: f32,
     pub current: f32,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -45,42 +45,41 @@ where
         self.jobs_done.insert(job.uid);
         self.job_factory.job_mark_done(&job);
 
-        let idx_node = job.node_cores.unwrap();
+        let uid_cores = job.node_cores.unwrap();
 
-        let all_idx_cores = vec![idx_node];
+        let all_uids_cores = vec![uid_cores];
         // VV: after finding the index of the node in the sorted_cores array
         // it's now safe to free cores
-        self.registry.nodes[idx_node].free_cores(job.cores);
+        self.registry.nodes[uid_cores].free_cores(job.cores);
 
-        let all_idx_memory: Vec<usize> = job
+        let all_uids_memory: Vec<usize> = job
             .node_memory
             .iter()
-            .map(|&(idx_node, memory)| {
-                let node = &mut self.registry.nodes[idx_node];
+            .map(|&(uid_memory, memory)| {
+                let node = &mut self.registry.nodes[uid_memory];
                 // println!(
                 //     "Freeing {} memory from {} with max memory {}",
                 //     memory, node.name, node.memory.capacity
                 // );
                 node.free_memory(memory);
 
-                idx_node
+                uid_memory
             })
             .collect();
 
-        self.registry.resort_nodes_cores(&all_idx_cores);
-        self.registry.resort_nodes_memory(&all_idx_memory);
+        self.registry.resort_nodes_cores(&all_uids_cores);
+        self.registry.resort_nodes_memory(&all_uids_memory);
     }
 
     fn job_allocate_on_single_node(
         registry: &mut NodeRegistry,
         idx_cores: usize,
-        idx_memory: usize,
         job: &mut Job,
     ) {
-        let idx_node = registry.sorted_cores[idx_cores];
+        let uid_node = registry.sorted_cores[idx_cores];
 
         // VV: finally, actually allocate the job on the node
-        let node = &mut registry.nodes[idx_node];
+        let node = &mut registry.nodes[uid_node];
 
         // println!("Can fit {}x{} to {}", job.cores, job.memory, node);
 
@@ -91,8 +90,8 @@ where
         // VV: and then re-sort the sorted_cores and sorted_memory indices of
         // the registry. This ensures that the next allocation will find
         // the nodes in proper order.
-        registry.resort_nodes_cores(&vec![idx_cores]);
-        registry.resort_nodes_memory(&vec![idx_memory]);
+        registry.resort_nodes_cores(&vec![uid_node]);
+        registry.resort_nodes_memory(&vec![uid_node]);
     }
 
     fn job_allocate_on_many_nodes(
@@ -122,7 +121,7 @@ where
             return false;
         }
 
-        let mut indices_memory = vec![];
+        let mut uids_memory = vec![];
 
         let mut rem_mem = job.memory;
 
@@ -134,7 +133,7 @@ where
         if node_cores.memory.current > 0.0 {
             let alloc = rem_mem.min(node_cores.memory.current);
             job.node_memory.push((uid_cores, alloc));
-            indices_memory.push(uid_cores);
+            uids_memory.push(uid_cores);
 
             registry.nodes[uid_cores].allocate_memory(alloc);
             rem_mem -= alloc;
@@ -146,7 +145,7 @@ where
                 let alloc = rem_mem.min(node_mem.memory.current);
                 job.node_memory.push((*uid_mem, alloc));
 
-                indices_memory.push(*uid_mem);
+                uids_memory.push(*uid_mem);
                 registry.nodes[*uid_mem].allocate_memory(alloc);
                 rem_mem -= alloc;
 
@@ -159,8 +158,8 @@ where
         // println!("Scheduling {}x{} on Cores:{:?}, Memory:{:?}",
         // job.cores, job.memory, job.node_cores, job.node_memory);
 
-        registry.resort_nodes_cores(&vec![idx_cores]);
-        registry.resort_nodes_memory(&indices_memory);
+        registry.resort_nodes_cores(&vec![uid_cores]);
+        registry.resort_nodes_memory(&uids_memory);
 
         assert_eq!(rem_mem, 0.0);
 
@@ -183,10 +182,9 @@ where
             let mut idx_cores = cores;
 
             for uid_cores in all_cores {
-                if let Some(idx_inner) = all_memory.iter().position(|uid: &usize| uid == uid_cores)
+                if let Some(_) = all_memory.iter().position(|uid: &usize| uid == uid_cores)
                 {
-                    let idx_memory = idx_inner + memory;
-                    Self::job_allocate_on_single_node(registry, idx_cores, idx_memory, job);
+                    Self::job_allocate_on_single_node(registry, idx_cores, job);
                     return true;
                 }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 use crate::job::Job;
 use crate::job_factory::JobFactory;
 use crate::registry::NodeRegistry;
@@ -71,11 +90,7 @@ where
         self.registry.resort_nodes_memory(&all_uids_memory);
     }
 
-    fn job_allocate_on_single_node(
-        registry: &mut NodeRegistry,
-        idx_cores: usize,
-        job: &mut Job,
-    ) {
+    fn job_allocate_on_single_node(registry: &mut NodeRegistry, idx_cores: usize, job: &mut Job) {
         let uid_node = registry.sorted_cores[idx_cores];
 
         // VV: finally, actually allocate the job on the node
@@ -182,8 +197,7 @@ where
             let mut idx_cores = cores;
 
             for uid_cores in all_cores {
-                if let Some(_) = all_memory.iter().position(|uid: &usize| uid == uid_cores)
-                {
+                if let Some(_) = all_memory.iter().position(|uid: &usize| uid == uid_cores) {
                     Self::job_allocate_on_single_node(registry, idx_cores, job);
                     return true;
                 }


### PR DESCRIPTION
This PR also updates the main driver to display short (and encouraging?) messages each time at least 1000 Jobs finish. The messages also include the scheduler timestamp.

Also adds license.